### PR TITLE
"Add macOS support for VRMKit with example app"

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 53;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -399,6 +399,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = N9TDHQ977J;
 				INFOPLIST_FILE = Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -417,6 +418,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = N9TDHQ977J;
 				INFOPLIST_FILE = Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Example/MacExample.xcodeproj/project.pbxproj
+++ b/Example/MacExample.xcodeproj/project.pbxproj
@@ -1,0 +1,578 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A61BDC262D96588100FCE979 /* VRMKit in Frameworks */ = {isa = PBXBuildFile; productRef = A61BDC252D96588100FCE979 /* VRMKit */; };
+		A61BDC282D96588100FCE979 /* VRMSceneKit in Frameworks */ = {isa = PBXBuildFile; productRef = A61BDC272D96588100FCE979 /* VRMSceneKit */; };
+		A61BDC2A2D9658C000FCE979 /* VRMKit in Frameworks */ = {isa = PBXBuildFile; productRef = A61BDC292D9658C000FCE979 /* VRMKit */; };
+		A61BDC2C2D9658C000FCE979 /* VRMSceneKit in Frameworks */ = {isa = PBXBuildFile; productRef = A61BDC2B2D9658C000FCE979 /* VRMSceneKit */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A61BDBCC2D9657E900FCE979 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A61BDBAD2D9657E800FCE979 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A61BDBB42D9657E800FCE979;
+			remoteInfo = MacExample;
+		};
+		A61BDBD62D9657E900FCE979 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A61BDBAD2D9657E800FCE979 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A61BDBB42D9657E800FCE979;
+			remoteInfo = MacExample;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A61BDBB52D9657E800FCE979 /* MacExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MacExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A61BDBCB2D9657E900FCE979 /* MacExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MacExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A61BDBD52D9657E900FCE979 /* MacExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MacExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		A61BDBB72D9657E800FCE979 /* MacExample */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = MacExample;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A61BDBB22D9657E800FCE979 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A61BDC282D96588100FCE979 /* VRMSceneKit in Frameworks */,
+				A61BDC2A2D9658C000FCE979 /* VRMKit in Frameworks */,
+				A61BDC2C2D9658C000FCE979 /* VRMSceneKit in Frameworks */,
+				A61BDC262D96588100FCE979 /* VRMKit in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A61BDBC82D9657E900FCE979 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A61BDBD22D9657E900FCE979 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A61BDBAC2D9657E800FCE979 = {
+			isa = PBXGroup;
+			children = (
+				A61BDBB72D9657E800FCE979 /* MacExample */,
+				A61BDBB62D9657E800FCE979 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A61BDBB62D9657E800FCE979 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A61BDBB52D9657E800FCE979 /* MacExample.app */,
+				A61BDBCB2D9657E900FCE979 /* MacExampleTests.xctest */,
+				A61BDBD52D9657E900FCE979 /* MacExampleUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A61BDBB42D9657E800FCE979 /* MacExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A61BDBDF2D9657E900FCE979 /* Build configuration list for PBXNativeTarget "MacExample" */;
+			buildPhases = (
+				A61BDBB12D9657E800FCE979 /* Sources */,
+				A61BDBB22D9657E800FCE979 /* Frameworks */,
+				A61BDBB32D9657E800FCE979 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A61BDBB72D9657E800FCE979 /* MacExample */,
+			);
+			name = MacExample;
+			packageProductDependencies = (
+				A61BDC252D96588100FCE979 /* VRMKit */,
+				A61BDC272D96588100FCE979 /* VRMSceneKit */,
+				A61BDC292D9658C000FCE979 /* VRMKit */,
+				A61BDC2B2D9658C000FCE979 /* VRMSceneKit */,
+			);
+			productName = MacExample;
+			productReference = A61BDBB52D9657E800FCE979 /* MacExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A61BDBCA2D9657E900FCE979 /* MacExampleTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A61BDBE22D9657E900FCE979 /* Build configuration list for PBXNativeTarget "MacExampleTests" */;
+			buildPhases = (
+				A61BDBC72D9657E900FCE979 /* Sources */,
+				A61BDBC82D9657E900FCE979 /* Frameworks */,
+				A61BDBC92D9657E900FCE979 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A61BDBCD2D9657E900FCE979 /* PBXTargetDependency */,
+			);
+			name = MacExampleTests;
+			packageProductDependencies = (
+			);
+			productName = MacExampleTests;
+			productReference = A61BDBCB2D9657E900FCE979 /* MacExampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		A61BDBD42D9657E900FCE979 /* MacExampleUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A61BDBE52D9657E900FCE979 /* Build configuration list for PBXNativeTarget "MacExampleUITests" */;
+			buildPhases = (
+				A61BDBD12D9657E900FCE979 /* Sources */,
+				A61BDBD22D9657E900FCE979 /* Frameworks */,
+				A61BDBD32D9657E900FCE979 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A61BDBD72D9657E900FCE979 /* PBXTargetDependency */,
+			);
+			name = MacExampleUITests;
+			packageProductDependencies = (
+			);
+			productName = MacExampleUITests;
+			productReference = A61BDBD52D9657E900FCE979 /* MacExampleUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A61BDBAD2D9657E800FCE979 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1620;
+				LastUpgradeCheck = 1620;
+				TargetAttributes = {
+					A61BDBB42D9657E800FCE979 = {
+						CreatedOnToolsVersion = 16.2;
+					};
+					A61BDBCA2D9657E900FCE979 = {
+						CreatedOnToolsVersion = 16.2;
+						TestTargetID = A61BDBB42D9657E800FCE979;
+					};
+					A61BDBD42D9657E900FCE979 = {
+						CreatedOnToolsVersion = 16.2;
+						TestTargetID = A61BDBB42D9657E800FCE979;
+					};
+				};
+			};
+			buildConfigurationList = A61BDBB02D9657E800FCE979 /* Build configuration list for PBXProject "MacExample" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A61BDBAC2D9657E800FCE979;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				A61BDC242D96588100FCE979 /* XCLocalSwiftPackageReference "../../VRMKit" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = A61BDBB62D9657E800FCE979 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A61BDBB42D9657E800FCE979 /* MacExample */,
+				A61BDBCA2D9657E900FCE979 /* MacExampleTests */,
+				A61BDBD42D9657E900FCE979 /* MacExampleUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A61BDBB32D9657E800FCE979 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A61BDBC92D9657E900FCE979 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A61BDBD32D9657E900FCE979 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A61BDBB12D9657E800FCE979 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A61BDBC72D9657E900FCE979 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A61BDBD12D9657E900FCE979 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A61BDBCD2D9657E900FCE979 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A61BDBB42D9657E800FCE979 /* MacExample */;
+			targetProxy = A61BDBCC2D9657E900FCE979 /* PBXContainerItemProxy */;
+		};
+		A61BDBD72D9657E900FCE979 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A61BDBB42D9657E800FCE979 /* MacExample */;
+			targetProxy = A61BDBD62D9657E900FCE979 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		A61BDBDD2D9657E900FCE979 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A61BDBDE2D9657E900FCE979 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		A61BDBE02D9657E900FCE979 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = MacExample/MacExample.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N9TDHQ977J;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.tattn.VRMMacExample.MacExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		A61BDBE12D9657E900FCE979 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = MacExample/MacExample.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N9TDHQ977J;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.tattn.VRMMacExample.MacExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		A61BDBE32D9657E900FCE979 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N9TDHQ977J;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.tattn.VRMMacExample.MacExampleTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MacExample.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/MacExample";
+			};
+			name = Debug;
+		};
+		A61BDBE42D9657E900FCE979 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N9TDHQ977J;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.tattn.VRMMacExample.MacExampleTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MacExample.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/MacExample";
+			};
+			name = Release;
+		};
+		A61BDBE62D9657E900FCE979 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N9TDHQ977J;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.tattn.VRMMacExample.MacExampleUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = MacExample;
+			};
+			name = Debug;
+		};
+		A61BDBE72D9657E900FCE979 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N9TDHQ977J;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.tattn.VRMMacExample.MacExampleUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = MacExample;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A61BDBB02D9657E800FCE979 /* Build configuration list for PBXProject "MacExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A61BDBDD2D9657E900FCE979 /* Debug */,
+				A61BDBDE2D9657E900FCE979 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A61BDBDF2D9657E900FCE979 /* Build configuration list for PBXNativeTarget "MacExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A61BDBE02D9657E900FCE979 /* Debug */,
+				A61BDBE12D9657E900FCE979 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A61BDBE22D9657E900FCE979 /* Build configuration list for PBXNativeTarget "MacExampleTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A61BDBE32D9657E900FCE979 /* Debug */,
+				A61BDBE42D9657E900FCE979 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A61BDBE52D9657E900FCE979 /* Build configuration list for PBXNativeTarget "MacExampleUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A61BDBE62D9657E900FCE979 /* Debug */,
+				A61BDBE72D9657E900FCE979 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		A61BDC242D96588100FCE979 /* XCLocalSwiftPackageReference "../../VRMKit" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../VRMKit;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A61BDC252D96588100FCE979 /* VRMKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = VRMKit;
+		};
+		A61BDC272D96588100FCE979 /* VRMSceneKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = VRMSceneKit;
+		};
+		A61BDC292D9658C000FCE979 /* VRMKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = VRMKit;
+		};
+		A61BDC2B2D9658C000FCE979 /* VRMSceneKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = VRMSceneKit;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = A61BDBAD2D9657E800FCE979 /* Project object */;
+}

--- a/Example/MacExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/MacExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/MacExample/AppDelegate.swift
+++ b/Example/MacExample/AppDelegate.swift
@@ -1,0 +1,39 @@
+//
+//  AppDelegate.swift
+//  MacExample
+//
+//  Created with Claude Code
+//
+
+import Cocoa
+import SwiftUI
+
+@main
+class AppDelegate: NSObject, NSApplicationDelegate {
+    var window: NSWindow!
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Create the SwiftUI view that holds the SceneKit view
+        let contentView = ContentView()
+        
+        // Create the window
+        window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "VRMKit macOS Example"
+        window.center()
+        
+        // Set SwiftUI view as the window's content view
+        window.contentView = NSHostingView(rootView: contentView)
+        
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        return true
+    }
+}

--- a/Example/MacExample/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Example/MacExample/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/MacExample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/MacExample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/MacExample/Assets.xcassets/Contents.json
+++ b/Example/MacExample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/MacExample/Base.lproj/Main.storyboard
+++ b/Example/MacExample/Base.lproj/Main.storyboard
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
+    </dependencies>
+    <scenes>
+        <!--Application-->
+        <scene sceneID="JPo-4y-FX3">
+            <objects>
+                <application id="hnw-xV-0zn" sceneMemberID="viewController">
+                    <menu key="mainMenu" title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
+                        <items>
+                            <menuItem title="VRMKit macOS Example" id="1Xt-HY-uBw">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="VRMKit macOS Example" systemMenu="apple" id="uQy-DD-JDr">
+                                    <items>
+                                        <menuItem title="Quit VRMKit macOS Example" keyEquivalent="q" id="4sb-4s-VLi">
+                                            <connections>
+                                                <action selector="terminate:" target="Ady-hI-5gd" id="Te7-pn-YzF"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                        </items>
+                    </menu>
+                    <connections>
+                        <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
+                    </connections>
+                </application>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="MacExample" customModuleProvider="target"/>
+                <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="0.0"/>
+        </scene>
+    </scenes>
+</document>

--- a/Example/MacExample/ContentView.swift
+++ b/Example/MacExample/ContentView.swift
@@ -1,0 +1,98 @@
+//
+//  ContentView.swift
+//  MacExample
+//
+//  Created with Claude Code
+//
+
+import SwiftUI
+import SceneKit
+import VRMKit
+import VRMSceneKit
+import AppKit
+
+struct ContentView: View {
+    @StateObject private var viewModel = ViewModel()
+    
+    var body: some View {
+        VStack {
+            SceneKitView(scene: viewModel.scene, delegate: viewModel)
+                .frame(minWidth: 400, minHeight: 300)
+            
+            HStack {
+                VStack(alignment: .leading) {
+                    Text("Blend Shapes")
+                        .font(.headline)
+                    
+                    HStack {
+                        Text("Joy")
+                        Slider(value: $viewModel.joyValue, in: 0...1)
+                            .frame(width: 200)
+                    }
+                    
+                    HStack {
+                        Text("Angry")
+                        Slider(value: $viewModel.angryValue, in: 0...1)
+                            .frame(width: 200)
+                    }
+                    
+                    HStack {
+                        Text("><")
+                        Slider(value: $viewModel.customValue, in: 0...1)
+                            .frame(width: 200)
+                    }
+                }
+                .padding()
+                
+                VStack(alignment: .leading) {
+                    Text("Humanoid Control")
+                        .font(.headline)
+                    
+                    HStack {
+                        Text("Neck Rotation")
+                        Slider(value: $viewModel.neckRotation, in: -45...45)
+                            .frame(width: 200)
+                    }
+                    
+                    HStack {
+                        Text("Shoulder Rotation")
+                        Slider(value: $viewModel.shoulderRotation, in: -45...45)
+                            .frame(width: 200)
+                    }
+                }
+                .padding()
+            }
+        }
+        .padding()
+    }
+}
+
+// SceneKit View Wrapper for SwiftUI
+struct SceneKitView: NSViewRepresentable {
+    let scene: SCNScene?
+    let delegate: SCNSceneRendererDelegate?
+    
+    init(scene: SCNScene?, delegate: SCNSceneRendererDelegate? = nil) {
+        self.scene = scene
+        self.delegate = delegate
+    }
+    
+    func makeNSView(context: Context) -> SCNView {
+        let view = SCNView()
+        view.scene = scene
+        view.autoenablesDefaultLighting = true
+        view.allowsCameraControl = true
+        view.showsStatistics = true
+        view.backgroundColor = .black
+        view.delegate = delegate
+        return view
+    }
+    
+    func updateNSView(_ nsView: SCNView, context: Context) {
+        // Updates happen via the delegate
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Example/MacExample/Info.plist
+++ b/Example/MacExample/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIconFile</key>
+    <string></string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+    <key>NSMainStoryboardFile</key>
+    <string>Main</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.graphics-design</string>
+</dict>
+</plist>

--- a/Example/MacExample/MacExample.entitlements
+++ b/Example/MacExample/MacExample.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/MacExample/README.md
+++ b/Example/MacExample/README.md
@@ -1,0 +1,51 @@
+# VRMKit macOS Example
+
+This is an example macOS application that demonstrates the use of VRMKit with SceneKit on macOS.
+
+## Features
+
+- Loads and renders a VRM model using SceneKit
+- Demonstrates the use of blend shapes (facial expressions)
+- Shows how to control humanoid bones (neck, shoulders)
+- Built with SwiftUI and Combine for a modern macOS application
+
+## Requirements
+
+- macOS 12.0+
+- Xcode 14.0+
+- Swift 5.7+
+
+## Getting Started
+
+1. Open the Example.xcodeproj in Xcode
+2. Select the "MacExample" target
+3. Build and run the application
+
+## Usage
+
+The application provides:
+
+- A 3D view of the VRM model that can be rotated and zoomed
+- Sliders to control blend shapes (Joy, Angry, etc.)
+- Sliders to control neck and shoulder rotations
+
+## Implementation Details
+
+This example demonstrates several key aspects of using VRMKit on macOS:
+
+- Using the PlatformImage and PlatformColor abstractions
+- Handling macOS-specific SceneKit views
+- Using SwiftUI for the user interface
+- Using Combine for reactive updates
+
+## Notes
+
+The example looks for "AliciaSolid.vrm" in the app bundle. If not found, it will try to access it from the test assets directory.
+
+## Troubleshooting
+
+If you encounter issues:
+
+1. Make sure you've copied the model file to the project
+2. Check that the VRMKit and VRMSceneKit targets are properly linked
+3. Verify that your macOS deployment target is 12.0 or higher

--- a/Example/MacExample/SETUP.md
+++ b/Example/MacExample/SETUP.md
@@ -1,0 +1,86 @@
+# Adding MacExample to the Xcode Project
+
+To add the macOS example to your Xcode project, follow these steps:
+
+## 1. Open the existing project
+
+Open the `Example.xcodeproj` file in Xcode.
+
+## 2. Add a new macOS target
+
+1. Click on the project file in the Project Navigator
+2. Click the + button at the bottom of the Targets list
+3. Select "macOS" tab
+4. Choose "App" template and click Next
+5. Configure the new target:
+   - Product Name: MacExample
+   - Team: Select your team
+   - Organization Identifier: (same as the existing project)
+   - Bundle Identifier: (automatically generated)
+   - Language: Swift
+   - Interface: SwiftUI (or Storyboard if needed)
+   - Leave the checkboxes as default
+6. Click Finish
+
+## 3. Delete the auto-generated files
+
+You can delete the auto-generated files that Xcode creates since you'll use the files we've prepared.
+
+## 4. Add our example files to the project
+
+1. Right-click on the MacExample target in the Project Navigator
+2. Select "Add Files to 'MacExample'..."
+3. Navigate to the MacExample directory and select all the following files:
+   - AppDelegate.swift
+   - ContentView.swift
+   - ViewModel.swift
+   - Info.plist
+   - Assets.xcassets (folder)
+   - Base.lproj (folder with Main.storyboard)
+   - AliciaSolid.vrm (model file)
+   - MacExample.entitlements
+   - README.md (optional)
+4. Make sure "Copy items if needed" is checked
+5. Make sure the target is set to MacExample
+6. Click Add
+
+## 5. Configure the target build settings
+
+1. Select the MacExample target in the Project Navigator
+2. Go to the Build Settings tab
+3. Ensure macOS Deployment Target is set to 12.0 or higher
+4. Under Packaging, make sure Info.plist File is set to `MacExample/Info.plist`
+
+## 6. Link with VRMKit frameworks
+
+1. Select the MacExample target in the Project Navigator
+2. Go to the General tab
+3. Under Frameworks, Libraries, and Embedded Content, click the + button
+4. Add both VRMKit and VRMSceneKit frameworks
+
+## 7. Add model to the build phases
+
+1. Select the MacExample target in the Project Navigator
+2. Go to the Build Phases tab
+3. Expand "Copy Bundle Resources"
+4. Ensure AliciaSolid.vrm is listed there (add it if not)
+
+## 8. Run the app
+
+1. Select the MacExample scheme from the scheme selector
+2. Choose a macOS simulator or your Mac as the run destination
+3. Click Run
+
+## Troubleshooting
+
+If you encounter build errors:
+
+1. Check that all files are properly added to the target
+2. Verify Info.plist paths are correct
+3. Ensure the frameworks are properly linked
+4. Make sure the model file is included in the bundle
+
+If the VRM model doesn't appear:
+- Check the console for file loading errors
+- Verify the file path in ViewModel.swift
+- Ensure the VRM file is included in the Copy Bundle Resources phase

--- a/Example/MacExample/ViewModel.swift
+++ b/Example/MacExample/ViewModel.swift
@@ -1,0 +1,115 @@
+//
+//  ViewModel.swift
+//  MacExample
+//
+//  Created with Claude Code
+//
+
+import Foundation
+import SceneKit
+import VRMKit
+import VRMSceneKit
+import Combine
+import AppKit
+
+class ViewModel: ObservableObject, SCNSceneRendererDelegate {
+    var scene: SCNScene?
+    private var vrmNode: VRMNode?
+    private var updateTimer: Timer?
+    
+    @Published var joyValue: Double = 0 {
+        didSet { updateBlendShape(.preset(.joy), value: joyValue) }
+    }
+    
+    @Published var angryValue: Double = 0 {
+        didSet { updateBlendShape(.preset(.angry), value: angryValue) }
+    }
+    
+    @Published var customValue: Double = 0 {
+        didSet { updateBlendShape(.custom("><"), value: customValue) }
+    }
+    
+    @Published var neckRotation: Double = 0 {
+        didSet { updateNeckRotation() }
+    }
+    
+    @Published var shoulderRotation: Double = 0 {
+        didSet { updateShoulderRotation() }
+    }
+    
+    init() {
+        loadVRM()
+        setupUpdateTimer()
+    }
+    
+    private func loadVRM() {
+        do {
+            // Look for VRM file in the bundle
+            guard let vrmURL = Bundle.main.url(forResource: "AliciaSolid", withExtension: "vrm") else {
+                // Use the test assets if not found in the bundle
+                let testAssetsURL = URL(fileURLWithPath: "/Users/harper/Public/src/2389/char/VRMKit/Tests/VRMKitTests/Assets/AliciaSolid.vrm")
+                let loader = try VRMSceneLoader(url: testAssetsURL)
+                scene = try loader.loadScene()
+                setupScene()
+                vrmNode = (scene as? VRMScene)?.vrmNode
+                return
+            }
+            
+            let loader = try VRMSceneLoader(url: vrmURL)
+            scene = try loader.loadScene()
+            setupScene()
+            vrmNode = (scene as? VRMScene)?.vrmNode
+        } catch {
+            print("Error loading VRM: \(error)")
+        }
+    }
+    
+    private func setupScene() {
+        guard let scene = scene else { return }
+        
+        // Setup camera
+        let cameraNode = SCNNode()
+        cameraNode.camera = SCNCamera()
+        scene.rootNode.addChildNode(cameraNode)
+        
+        cameraNode.position = SCNVector3(0, 0.8, -1.6)
+        cameraNode.rotation = SCNVector4(0, 1, 0, Float.pi)
+        
+        // Add rotation animation
+        (scene as? VRMScene)?.vrmNode.runAction(SCNAction.repeatForever(SCNAction.sequence([
+            SCNAction.rotateBy(x: 0, y: -0.5, z: 0, duration: 0.5),
+            SCNAction.rotateBy(x: 0, y: 0.5, z: 0, duration: 0.5),
+        ])))
+    }
+    
+    private func setupUpdateTimer() {
+        // No need for timer with delegate-based rendering
+        // We'll use the SCNSceneRendererDelegate methods instead
+    }
+    
+    // MARK: - SCNSceneRendererDelegate
+    
+    func renderer(_ renderer: SCNSceneRenderer, updateAtTime time: TimeInterval) {
+        guard let scene = scene as? VRMScene else { return }
+        scene.vrmNode.update(at: time)
+    }
+    
+    private func updateBlendShape(_ blendShape: VRMBlendShapeKey, value: Double) {
+        vrmNode?.setBlendShape(value: Float(value), for: blendShape)
+    }
+    
+    private func updateNeckRotation() {
+        vrmNode?.humanoid.node(for: .neck)?.eulerAngles = 
+            SCNVector3(0, 0, Float(neckRotation) * Float.pi / 180)
+    }
+    
+    private func updateShoulderRotation() {
+        let rotation = Float(shoulderRotation) * Float.pi / 180
+        vrmNode?.humanoid.node(for: .leftShoulder)?.eulerAngles = SCNVector3(0, 0, rotation)
+        vrmNode?.humanoid.node(for: .rightShoulder)?.eulerAngles = SCNVector3(0, 0, rotation)
+    }
+    
+    deinit {
+        updateTimer?.invalidate()
+    }
+}

--- a/MACOS_SUPPORT.md
+++ b/MACOS_SUPPORT.md
@@ -1,0 +1,84 @@
+# VRMKit macOS Support
+
+VRMKit now fully supports macOS platforms (macOS 12+) alongside iOS and watchOS.
+
+## Overview
+
+The macOS port allows you to use VRMKit in macOS applications, enabling VRM file loading, rendering, and manipulation using the same APIs that were previously available only on iOS and watchOS.
+
+## Key Changes
+
+1. **Platform Abstraction**
+   - Added macOS as a supported platform in Package.swift
+   - Created platform-agnostic typealias for UIKit/AppKit types:
+     - `PlatformImage` (UIImage → NSImage)
+     - `PlatformColor` (UIColor → NSColor)
+     - `SKColor` (UIColor → NSColor on macOS)
+
+2. **Image Handling**
+   - Implemented macOS-specific image loading and processing
+   - Added proper CGImage conversion for NSImage
+   - Handled platform-specific texture creation
+
+3. **Drawing and Rendering**
+   - Updated all color references to use platform-agnostic types
+   - Implemented debug gizmo drawing for macOS
+   - Ensured NSValue compatibility across platforms
+
+## Usage
+
+No API changes are required for existing code. The library automatically selects the appropriate implementation based on the platform.
+
+### Swift Package Manager
+
+Update your package dependencies to use the latest version of VRMKit:
+
+```swift
+.package(url: "https://github.com/your-org/VRMKit.git", from: "x.y.z")
+```
+
+### Project Setup
+
+For new projects, ensure you have the correct dependencies:
+
+```swift
+import VRMKit        // Core VRM parsing
+import VRMSceneKit   // SceneKit integration
+```
+
+## Example
+
+Loading a VRM file works the same way on all platforms:
+
+```swift
+import VRMKit
+import VRMSceneKit
+
+// Load a VRM file
+let url = URL(fileURLWithPath: "/path/to/model.vrm")
+let loader = try VRMSceneLoader(url: url)
+let scene = try loader.loadScene()
+
+// On macOS, add to SCNView
+let scnView = SCNView(frame: view.bounds)
+scnView.scene = scene
+view.addSubview(scnView)
+```
+
+## Compatibility Notes
+
+- The core rendering uses SceneKit, which is available on all Apple platforms
+- Some visual differences may occur due to different color management between platforms
+- Performance characteristics may vary between macOS and iOS
+
+## Known Issues
+
+- Some advanced shader features might render differently on macOS
+- The example app hasn't been ported to macOS yet (coming soon)
+
+## Contributing
+
+If you encounter any platform-specific issues, please submit an issue with details about:
+- macOS version
+- VRMKit version
+- Sample code or VRM file that demonstrates the issue

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "VRMKit",
-    platforms: [.iOS(.v15), .watchOS(.v8)],
+    platforms: [.iOS(.v15), .watchOS(.v8), .macOS(.v12)],
     products: [
         .library(name: "VRMKit", targets: ["VRMKit"]),
         .library(name: "VRMSceneKit", targets: ["VRMSceneKit"])

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ For "VRM", please refer to [this page](https://dwango.github.io/en/vrm/).
 - Swift 5.7+
 - iOS 15.0+
 - watchOS 8.0+ (Experimental)
+- macOS 12.0+ (See [MACOS_SUPPORT.md](./MACOS_SUPPORT.md))
 
 # Installation
 

--- a/Sources/VRMSceneKit/CustomType/VRMSpringBone.swift
+++ b/Sources/VRMSceneKit/CustomType/VRMSpringBone.swift
@@ -10,6 +10,14 @@ import SceneKit
 import GameKit
 import VRMKit
 
+#if canImport(UIKit)
+import UIKit
+typealias PlatformColor = UIColor
+#elseif canImport(AppKit)
+import AppKit
+typealias PlatformColor = NSColor
+#endif
+
 final class VRMSpringBone {
     struct SphereCollider {
         let position: SIMD3<Float>
@@ -142,7 +150,7 @@ final class VRMSpringBone {
                     base: baseNode,
                     center: self.center,
                     radius: self.hitRadius,
-                    color: UIColor.yellow,
+                    color: PlatformColor.yellow,
                     gizmoNodeName: gizmoNodeName
                 )
             }
@@ -220,14 +228,14 @@ extension VRMSpringBone {
             return nextTail
         }
         
-        func drawGizmo(base: SCNNode, center: SCNNode?, radius: simd_float1, color: UIColor, gizmoNodeName: String) {
+        func drawGizmo(base: SCNNode, center: SCNNode?, radius: simd_float1, color: PlatformColor, gizmoNodeName: String) {
             let currentTail = center?.utx.transformPoint(self.currentTail) ?? self.currentTail
             let prevTail = center?.utx.transformPoint(self.prevTail) ?? self.prevTail
 
             let prevGizmoGeometry = SCNSphere(radius: CGFloat(radius))
             let prevGizmoNode = SCNNode(geometry: prevGizmoGeometry)
             prevGizmoNode.name = gizmoNodeName
-            prevGizmoNode.geometry?.firstMaterial?.diffuse.contents = UIColor.gray
+            prevGizmoNode.geometry?.firstMaterial?.diffuse.contents = PlatformColor.gray
             base.addChildNode(prevGizmoNode)
             prevGizmoNode.simdWorldPosition = prevTail
             

--- a/Sources/VRMSceneKit/CustomType/VRMSpringBone.swift
+++ b/Sources/VRMSceneKit/CustomType/VRMSpringBone.swift
@@ -9,13 +9,14 @@
 import SceneKit
 import GameKit
 import VRMKit
+import Foundation
 
 #if canImport(UIKit)
 import UIKit
-typealias PlatformColor = UIColor
+public typealias PlatformColor = UIColor
 #elseif canImport(AppKit)
 import AppKit
-typealias PlatformColor = NSColor
+public typealias PlatformColor = NSColor
 #endif
 
 final class VRMSpringBone {

--- a/Sources/VRMSceneKit/Extensions/SceneKit+.swift
+++ b/Sources/VRMSceneKit/Extensions/SceneKit+.swift
@@ -8,16 +8,14 @@
 
 import SceneKit
 import SpriteKit
+import Foundation
 
 #if canImport(UIKit)
 import UIKit
-typealias PlatformColor = UIColor
-// On iOS, SpriteKit's SKColor is already defined as UIColor
+public typealias SKColor = UIColor
 #elseif canImport(AppKit)
 import AppKit
-typealias PlatformColor = NSColor
-// Define SKColor for macOS
-typealias SKColor = NSColor
+public typealias SKColor = NSColor
 #endif
 
 extension SCNVector3 {
@@ -105,6 +103,14 @@ extension SCNMatrix4 {
                   m21: v[4], m22: v[5], m23: v[6], m24: v[7],
                   m31: v[8], m32: v[9], m33: v[10], m34: v[11],
                   m41: v[12], m42: v[13], m43: v[14], m44: v[15])
+    }
+    
+    init(_ v: [Float]) throws {
+        guard v.count == 16 else { throw "SCNMatrix4: values.count must be 16" }
+        self.init(m11: SCNFloat(v[0]), m12: SCNFloat(v[1]), m13: SCNFloat(v[2]), m14: SCNFloat(v[3]),
+                  m21: SCNFloat(v[4]), m22: SCNFloat(v[5]), m23: SCNFloat(v[6]), m24: SCNFloat(v[7]),
+                  m31: SCNFloat(v[8]), m32: SCNFloat(v[9]), m33: SCNFloat(v[10]), m34: SCNFloat(v[11]),
+                  m41: SCNFloat(v[12]), m42: SCNFloat(v[13]), m43: SCNFloat(v[14]), m44: SCNFloat(v[15]))
     }
     
     static func * (_ left: SCNMatrix4, right: SCNMatrix4) -> SCNMatrix4 {

--- a/Sources/VRMSceneKit/Extensions/SceneKit+.swift
+++ b/Sources/VRMSceneKit/Extensions/SceneKit+.swift
@@ -9,6 +9,17 @@
 import SceneKit
 import SpriteKit
 
+#if canImport(UIKit)
+import UIKit
+typealias PlatformColor = UIColor
+// On iOS, SpriteKit's SKColor is already defined as UIColor
+#elseif canImport(AppKit)
+import AppKit
+typealias PlatformColor = NSColor
+// Define SKColor for macOS
+typealias SKColor = NSColor
+#endif
+
 extension SCNVector3 {
     static func + (_ left: SCNVector3, _ right: SCNVector3) -> SCNVector3 {
         SCNVector3(left.x + right.x, left.y + right.y, left.z + right.z)

--- a/Sources/VRMSceneKit/Extensions/simd+.swift
+++ b/Sources/VRMSceneKit/Extensions/simd+.swift
@@ -27,10 +27,51 @@ extension simd_float4x4 {
     func multiplyPoint(_ v: SIMD3<Float>) -> SIMD3<Float> {
         let scn = SCNMatrix4(self)
         var vector3: SIMD3<Float> = SIMD3<Float>()
-        vector3.x = (scn.m11 * v.x + scn.m21 * v.y + scn.m31 * v.z) + scn.m41
-        vector3.y = (scn.m12 * v.x + scn.m22 * v.y + scn.m32 * v.z) + scn.m42
-        vector3.z = (scn.m13 * v.x + scn.m23 * v.y + scn.m33 * v.z) + scn.m43
-        let num: Float = 1.0 / ((scn.m14 * v.x + scn.m24 * v.y + scn.m34 * v.z) + scn.m44)
+        
+        // Breaking up the expressions to help the type checker
+        // Convert CGFloat to Float for all operations
+        let m11 = Float(scn.m11)
+        let m12 = Float(scn.m12)
+        let m13 = Float(scn.m13)
+        let m14 = Float(scn.m14)
+        let m21 = Float(scn.m21)
+        let m22 = Float(scn.m22)
+        let m23 = Float(scn.m23)
+        let m24 = Float(scn.m24)
+        let m31 = Float(scn.m31)
+        let m32 = Float(scn.m32)
+        let m33 = Float(scn.m33)
+        let m34 = Float(scn.m34)
+        let m41 = Float(scn.m41)
+        let m42 = Float(scn.m42)
+        let m43 = Float(scn.m43)
+        let m44 = Float(scn.m44)
+        
+        // Row 1
+        let x1 = m11 * v.x
+        let y1 = m21 * v.y
+        let z1 = m31 * v.z
+        vector3.x = (x1 + y1 + z1) + m41
+        
+        // Row 2
+        let x2 = m12 * v.x
+        let y2 = m22 * v.y
+        let z2 = m32 * v.z
+        vector3.y = (x2 + y2 + z2) + m42
+        
+        // Row 3
+        let x3 = m13 * v.x
+        let y3 = m23 * v.y
+        let z3 = m33 * v.z
+        vector3.z = (x3 + y3 + z3) + m43
+        
+        // W component for perspective division
+        let w1 = m14 * v.x
+        let w2 = m24 * v.y
+        let w3 = m34 * v.z
+        let w = (w1 + w2 + w3) + m44
+        let num: Float = 1.0 / w
+        
         vector3.x *= num
         vector3.y *= num
         vector3.z *= num

--- a/Sources/VRMSceneKit/GLTF2SCN/GLTF2SCN.swift
+++ b/Sources/VRMSceneKit/GLTF2SCN/GLTF2SCN.swift
@@ -11,19 +11,6 @@ import Foundation
 import SceneKit
 import SpriteKit
 
-#if canImport(UIKit)
-import UIKit
-typealias PlatformColor = UIColor
-typealias PlatformImage = UIImage
-// On iOS, SpriteKit's SKColor is already defined as UIColor
-#elseif canImport(AppKit)
-import AppKit
-typealias PlatformColor = NSColor
-typealias PlatformImage = NSImage
-// Define SKColor for macOS
-typealias SKColor = NSColor
-#endif
-
 func semantic(of key: GLTF.Mesh.Primitive.AttributeKey) -> SCNGeometrySource.Semantic {
     switch key {
     case .POSITION: return .vertex

--- a/Sources/VRMSceneKit/GLTF2SCN/GLTF2SCN.swift
+++ b/Sources/VRMSceneKit/GLTF2SCN/GLTF2SCN.swift
@@ -11,6 +11,19 @@ import Foundation
 import SceneKit
 import SpriteKit
 
+#if canImport(UIKit)
+import UIKit
+typealias PlatformColor = UIColor
+typealias PlatformImage = UIImage
+// On iOS, SpriteKit's SKColor is already defined as UIColor
+#elseif canImport(AppKit)
+import AppKit
+typealias PlatformColor = NSColor
+typealias PlatformImage = NSImage
+// Define SKColor for macOS
+typealias SKColor = NSColor
+#endif
+
 func semantic(of key: GLTF.Mesh.Primitive.AttributeKey) -> SCNGeometrySource.Semantic {
     switch key {
     case .POSITION: return .vertex

--- a/Sources/VRMSceneKit/GLTF2SCN/InverseBindMatrix+GLTF.swift
+++ b/Sources/VRMSceneKit/GLTF2SCN/InverseBindMatrix+GLTF.swift
@@ -35,6 +35,7 @@ extension Array where Element == InverseBindMatrix {
                 let values = (0..<componentsPerVector)
                     .map { rawPtr.load(fromByteOffset: $0*bytesPerComponent, as: Float.self) }
 //                    .map { SCNFloat($0) }
+                // Use the new initializer that accepts Float array directly
                 matrices.append(InverseBindMatrix(scnMatrix4: try SCNMatrix4(values)))
                 ptr = ptr.advanced(by: stride)
             }

--- a/Sources/VRMSceneKit/GLTF2SCN/InverseBindMatrix+GLTF.swift
+++ b/Sources/VRMSceneKit/GLTF2SCN/InverseBindMatrix+GLTF.swift
@@ -8,7 +8,9 @@
 
 import VRMKit
 import SceneKit
+import Foundation
 
+// NSValue is available on both platforms and provides value boxing functionality
 typealias InverseBindMatrix = NSValue
 
 extension Array where Element == InverseBindMatrix {

--- a/Sources/VRMSceneKit/GLTF2SCN/SCNMaterial+GLTF.swift
+++ b/Sources/VRMSceneKit/GLTF2SCN/SCNMaterial+GLTF.swift
@@ -10,6 +10,16 @@ import VRMKit
 import SceneKit
 import SpriteKit
 
+#if canImport(UIKit)
+import UIKit
+typealias PlatformImage = UIImage
+typealias PlatformColor = UIColor
+#elseif canImport(AppKit)
+import AppKit
+typealias PlatformImage = NSImage
+typealias PlatformColor = NSColor
+#endif
+
 extension SCNMaterial {
     convenience init(material: GLTF.Material, loader: VRMSceneLoader) throws {
         self.init()
@@ -53,7 +63,7 @@ extension SCNMaterial {
                 try metalness.setTextureInfo(metallicTexture, loader: loader)
                 try roughness.setTextureInfo(metallicTexture, loader: loader)
 
-                let image = try metalness.contents as? UIImage ??? ._dataInconsistent("failed to load texture image")
+                let image = try metalness.contents as? PlatformImage ??? ._dataInconsistent("failed to load texture image")
                 let (metalTexture, roughTexture) = try createMetallicRoughnessTexture(from: image)
                 metalness.contents = metalTexture
                 roughness.contents = roughTexture
@@ -77,8 +87,9 @@ extension SCNMaterial {
         }
     }
 
-    private func createMetallicRoughnessTexture(from uiImage: UIImage) throws -> (metal: UIImage, rough: UIImage) {
-        let image = try uiImage.cgImage ??? ._dataInconsistent("failed to get cgImage")
+#if canImport(UIKit)
+    private func createMetallicRoughnessTexture(from platformImage: PlatformImage) throws -> (metal: PlatformImage, rough: PlatformImage) {
+        let image = try platformImage.cgImage ??? ._dataInconsistent("failed to get cgImage")
 
         // https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#pbrmetallicroughnessmetallicroughnesstexture
 
@@ -126,24 +137,94 @@ extension SCNMaterial {
 
     private func createGraySpaceImage(width: Int,
                                       height: Int,
-                                      dataPointer: UnsafeMutablePointer<UInt8>) throws -> UIImage {
+                                      dataPointer: UnsafeMutablePointer<UInt8>) throws -> PlatformImage {
         let data = try CFDataCreate(nil, dataPointer, width * height) ??? ._dataInconsistent("failed to create CFDataCreate")
         let provider = try CGDataProvider(data: data) ??? ._dataInconsistent("failed to create CGDataProvider")
-        return UIImage(cgImage:
-            try CGImage(
-                width: width,
-                height: height,
-                bitsPerComponent: 8,
-                bitsPerPixel: 8,
-                bytesPerRow: width * 1,
-                space: CGColorSpaceCreateDeviceGray(),
-                bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.none.rawValue),
-                provider: provider,
-                decode: nil,
-                shouldInterpolate: false,
-                intent: .defaultIntent) ??? ._dataInconsistent("failed to create CGImage")
-        )
+        let cgImage = try CGImage(
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 8,
+            bytesPerRow: width * 1,
+            space: CGColorSpaceCreateDeviceGray(),
+            bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.none.rawValue),
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent) ??? ._dataInconsistent("failed to create CGImage")
+        
+        return PlatformImage(cgImage: cgImage)
     }
+#elseif canImport(AppKit)
+    private func createMetallicRoughnessTexture(from platformImage: PlatformImage) throws -> (metal: PlatformImage, rough: PlatformImage) {
+        let cgImage = try platformImage.cgImage ??? ._dataInconsistent("failed to get cgImage")
+
+        // https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#pbrmetallicroughnessmetallicroughnesstexture
+
+        let pixelCount = cgImage.width * cgImage.height
+        let bitsPerComponent = 8
+        let componentsPerPixel = 4 // RGBA
+        let srcBytesPerPixel = bitsPerComponent * componentsPerPixel / 8
+        let srcDataSize = pixelCount * srcBytesPerPixel
+
+        let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: srcDataSize)
+        let metalPtr = UnsafeMutablePointer<UInt8>.allocate(capacity: pixelCount)
+        let roughPtr = UnsafeMutablePointer<UInt8>.allocate(capacity: pixelCount)
+        defer {
+            ptr.deallocate()
+            metalPtr.deallocate()
+            roughPtr.deallocate()
+        }
+
+        let context = try CGContext(
+            data: UnsafeMutableRawPointer(ptr),
+            width: cgImage.width,
+            height: cgImage.height,
+            bitsPerComponent: bitsPerComponent,
+            bytesPerRow: srcBytesPerPixel * cgImage.width,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue)
+            ??? ._dataInconsistent("failed to create cgcontext")
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: cgImage.width, height: cgImage.height))
+
+        for dstPos in 0..<pixelCount {
+            let srcPos = dstPos * srcBytesPerPixel
+            metalPtr[dstPos] = ptr[srcPos + 2] // blue
+            roughPtr[dstPos] = ptr[srcPos + 1] // green
+        }
+
+        let metalImage = try createGraySpaceImage(width: cgImage.width,
+                                                  height: cgImage.height,
+                                                  dataPointer: metalPtr)
+
+        let roughImage = try createGraySpaceImage(width: cgImage.width,
+                                                  height: cgImage.height,
+                                                  dataPointer: roughPtr)
+        return (metalImage, roughImage)
+    }
+
+    private func createGraySpaceImage(width: Int,
+                                      height: Int,
+                                      dataPointer: UnsafeMutablePointer<UInt8>) throws -> PlatformImage {
+        let data = try CFDataCreate(nil, dataPointer, width * height) ??? ._dataInconsistent("failed to create CFDataCreate")
+        let provider = try CGDataProvider(data: data) ??? ._dataInconsistent("failed to create CGDataProvider")
+        let cgImage = try CGImage(
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 8,
+            bytesPerRow: width * 1,
+            space: CGColorSpaceCreateDeviceGray(),
+            bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.none.rawValue),
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent) ??? ._dataInconsistent("failed to create CGImage")
+        
+        let size = NSSize(width: width, height: height)
+        return NSImage(cgImage: cgImage, size: size)
+    }
+#endif
 
     private func blendMode(of alphaMode: GLTF.Material.AlphaMode) -> SCNBlendMode {
         // FIXME/TODO: https://dwango.github.io/vrm/vrm_spec/#vrm%E3%81%8C%E6%8F%90%E4%BE%9B%E3%81%99%E3%82%8B%E3%82%B7%E3%82%A7%E3%83%BC%E3%83%80%E3%83%BC

--- a/Sources/VRMSceneKit/GLTF2SCN/SCNMaterial+GLTF.swift
+++ b/Sources/VRMSceneKit/GLTF2SCN/SCNMaterial+GLTF.swift
@@ -9,16 +9,7 @@
 import VRMKit
 import SceneKit
 import SpriteKit
-
-#if canImport(UIKit)
-import UIKit
-typealias PlatformImage = UIImage
-typealias PlatformColor = UIColor
-#elseif canImport(AppKit)
-import AppKit
-typealias PlatformImage = NSImage
-typealias PlatformColor = NSColor
-#endif
+import Foundation
 
 extension SCNMaterial {
     convenience init(material: GLTF.Material, loader: VRMSceneLoader) throws {

--- a/Sources/VRMSceneKit/GLTF2SCN/UIImage+GLTF.swift
+++ b/Sources/VRMSceneKit/GLTF2SCN/UIImage+GLTF.swift
@@ -7,8 +7,18 @@
 //
 
 import VRMKit
-import UIKit
+import Foundation
 
+#if canImport(UIKit)
+import UIKit
+typealias PlatformImage = UIImage
+#elseif canImport(AppKit)
+import AppKit
+typealias PlatformImage = NSImage
+#endif
+
+#if canImport(UIKit)
+// iOS, tvOS, etc.
 extension UIImage {
     convenience init(image: GLTF.Image, relativeTo rootDirectory: URL?, loader: VRMSceneLoader) throws {
         let data: Data
@@ -22,3 +32,30 @@ extension UIImage {
         self.init(cgImage: try UIImage(data: data)?.cgImage ??? ._dataInconsistent("failed to load image"))
     }
 }
+#elseif canImport(AppKit)
+// macOS
+extension NSImage {
+    convenience init(image: GLTF.Image, relativeTo rootDirectory: URL?, loader: VRMSceneLoader) throws {
+        let data: Data
+        if let uri = image.uri {
+            data = try Data(gltfUrlString: uri, relativeTo: rootDirectory)
+        } else if let bufferViewIndex = image.bufferView {
+            data = try loader.bufferView(withBufferViewIndex: bufferViewIndex).bufferView
+        } else {
+            throw VRMError._dataInconsistent("failed to load images")
+        }
+        
+        if let nsImage = NSImage(data: data) {
+            self.init(cgImage: nsImage.cgImage(forProposedRect: nil, context: nil, hints: nil)!, size: nsImage.size)
+        } else {
+            throw VRMError._dataInconsistent("failed to load image")
+        }
+    }
+    
+    var cgImage: CGImage? {
+        guard let imageData = self.tiffRepresentation else { return nil }
+        guard let sourceData = CGImageSourceCreateWithData(imageData as CFData, nil) else { return nil }
+        return CGImageSourceCreateImageAtIndex(sourceData, 0, nil)
+    }
+}
+#endif

--- a/Sources/VRMSceneKit/GLTF2SCN/UIImage+GLTF.swift
+++ b/Sources/VRMSceneKit/GLTF2SCN/UIImage+GLTF.swift
@@ -11,10 +11,10 @@ import Foundation
 
 #if canImport(UIKit)
 import UIKit
-typealias PlatformImage = UIImage
+public typealias PlatformImage = UIImage
 #elseif canImport(AppKit)
 import AppKit
-typealias PlatformImage = NSImage
+public typealias PlatformImage = NSImage
 #endif
 
 #if canImport(UIKit)

--- a/Sources/VRMSceneKit/SceneData.swift
+++ b/Sources/VRMSceneKit/SceneData.swift
@@ -10,14 +10,6 @@ import VRMKit
 import SceneKit
 import Foundation
 
-#if canImport(UIKit)
-import UIKit
-typealias PlatformImage = UIImage
-#elseif canImport(AppKit)
-import AppKit
-typealias PlatformImage = NSImage
-#endif
-
 final class SceneData {
     var scene: VRMScene?
     var scenes: [VRMScene?]
@@ -56,8 +48,10 @@ final class SceneData {
         images = Array(repeating: nil, count: vrm.images?.count ?? 0)
     }
 
-    func load<T>(_ keyPath: KeyPath<SceneData, [T]>, index: Int) throws -> T {
-        let values = self[keyPath: keyPath]
-        return try values[safe: index] ??? ._dataInconsistent("\(keyPath): out of index \(index) < \(values.count)")
+    // Helper for array access with validation
+    func validateIndex<T>(_ array: [T?], index: Int) throws {
+        guard index < array.count else {
+            throw VRMError._dataInconsistent("Index out of bounds: \(index) >= \(array.count)")
+        }
     }
 }

--- a/Sources/VRMSceneKit/SceneData.swift
+++ b/Sources/VRMSceneKit/SceneData.swift
@@ -8,7 +8,15 @@
 
 import VRMKit
 import SceneKit
+import Foundation
+
+#if canImport(UIKit)
 import UIKit
+typealias PlatformImage = UIImage
+#elseif canImport(AppKit)
+import AppKit
+typealias PlatformImage = NSImage
+#endif
 
 final class SceneData {
     var scene: VRMScene?
@@ -27,7 +35,7 @@ final class SceneData {
     var buffers: [Data?] = []
     var materials: [SCNMaterial?] = []
     var textures: [SCNMaterialProperty?] = []
-    var images: [UIImage?] = []
+    var images: [PlatformImage?] = []
 
     init(vrm: GLTF) {
         scenes = Array(repeating: nil, count: vrm.scenes?.count ?? 0)

--- a/Sources/VRMSceneKit/VRMSceneLoader.swift
+++ b/Sources/VRMSceneKit/VRMSceneLoader.swift
@@ -11,6 +11,14 @@ import VRMKit
 import SceneKit
 import SpriteKit
 
+#if canImport(UIKit)
+import UIKit
+typealias PlatformImage = UIImage
+#elseif canImport(AppKit)
+import AppKit
+typealias PlatformImage = NSImage
+#endif
+
 open class VRMSceneLoader {
     let vrm: VRM
     private let gltf: GLTF
@@ -46,7 +54,7 @@ open class VRMSceneLoader {
         return scnScene
     }
 
-    public func loadThumbnail() throws -> UIImage? {
+    public func loadThumbnail() throws -> PlatformImage? {
         guard let textureIndex = vrm.meta.texture else { return nil }
         if let cache = try sceneData.load(\.images, index: textureIndex) { return cache }
         return try image(withImageIndex: textureIndex)
@@ -153,10 +161,10 @@ open class VRMSceneLoader {
         return texture
     }
 
-    func image(withImageIndex index: Int) throws -> UIImage {
+    func image(withImageIndex index: Int) throws -> PlatformImage {
         if let cache = try sceneData.load(\.images, index: index) { return cache }
         let gltfImage = try gltf.load(\.images, keyName: "images")[index]
-        let image = try UIImage(image: gltfImage, relativeTo: rootDirectory, loader: self)
+        let image = try PlatformImage(image: gltfImage, relativeTo: rootDirectory, loader: self)
         sceneData.images[index] = image
         return image
     }

--- a/Sources/VRMSceneKit/VRMSceneLoader.swift
+++ b/Sources/VRMSceneKit/VRMSceneLoader.swift
@@ -13,10 +13,8 @@ import SpriteKit
 
 #if canImport(UIKit)
 import UIKit
-typealias PlatformImage = UIImage
 #elseif canImport(AppKit)
 import AppKit
-typealias PlatformImage = NSImage
 #endif
 
 open class VRMSceneLoader {
@@ -38,7 +36,11 @@ open class VRMSceneLoader {
     }
 
     public func loadScene(withSceneIndex index: Int) throws -> VRMScene {
-        if let cache = try sceneData.load(\.scenes, index: index) { return cache }
+        // Check if we already have the scene cached
+        if index < sceneData.scenes.count, let cache = sceneData.scenes[index] {
+            return cache
+        }
+        
         let gltfScene = try gltf.load(\.scenes, keyName: "scenes")[index]
         
         let vrmNode = VRMNode(vrm: vrm)
@@ -54,14 +56,20 @@ open class VRMSceneLoader {
         return scnScene
     }
 
+    /// Loads the thumbnail image from the VRM file
+    /// - Returns: The thumbnail image or nil if not available
     public func loadThumbnail() throws -> PlatformImage? {
         guard let textureIndex = vrm.meta.texture else { return nil }
-        if let cache = try sceneData.load(\.images, index: textureIndex) { return cache }
+        if textureIndex < sceneData.images.count, let cache = sceneData.images[textureIndex] {
+            return cache
+        }
         return try image(withImageIndex: textureIndex)
     }
 
     func node(withNodeIndex index: Int) throws -> SCNNode {
-        if let cache = try sceneData.load(\.nodes, index: index) { return cache }
+        if index < sceneData.nodes.count, let cache = sceneData.nodes[index] {
+            return cache
+        }
         let gltfNode = try gltf.load(\.nodes, keyName: "nodes")[index]
         let gltfSkins = try? gltf.load(\.skins, keyName: "skins")
         let scnNode = try SCNNode(node: gltfNode, skins: gltfSkins, loader: self)
@@ -70,7 +78,9 @@ open class VRMSceneLoader {
     }
 
     func camera(withCameraIndex index: Int) throws -> SCNCamera {
-        if let cache = try sceneData.load(\.cameras, index: index) { return cache }
+        if index < sceneData.cameras.count, let cache = sceneData.cameras[index] {
+            return cache
+        }
         let gltfCamera = try gltf.load(\.cameras, keyName: "cameras")[index]
         let camera = try SCNCamera(camera: gltfCamera)
         sceneData.cameras[index] = camera
@@ -78,7 +88,9 @@ open class VRMSceneLoader {
     }
 
     func mesh(withMeshIndex index: Int) throws -> SCNNode {
-        if let cache = try sceneData.load(\.meshes, index: index) { return cache }
+        if index < sceneData.meshes.count, let cache = sceneData.meshes[index] {
+            return cache
+        }
         let gltfMesh = try gltf.load(\.meshes, keyName: "meshes")[index]
         let mesh = try SCNNode(mesh: gltfMesh, loader: self)
         sceneData.meshes[index] = mesh
@@ -88,7 +100,9 @@ open class VRMSceneLoader {
     func attributes(_ attributes: [GLTF.Mesh.Primitive.AttributeKey: Int]) throws -> [SCNGeometrySource] {
         return try attributes.compactMap { attribute, index in
             guard attribute != .COLOR_0 else { return nil } // FIXME
-            if let cache = try sceneData.load(\.accessors, index: index) as? SCNGeometrySource { return cache }
+            if index < sceneData.accessors.count, let cache = sceneData.accessors[index] as? SCNGeometrySource {
+                return cache
+            }
             let gltfAccessor = try gltf.load(\.accessors, keyName: "accessors")[index]
             let geometrySource = try SCNGeometrySource(accessor: gltfAccessor, semantic: semantic(of: attribute), loader: self)
             sceneData.accessors[index] = geometrySource
@@ -97,7 +111,9 @@ open class VRMSceneLoader {
     }
 
     func indexAccessor(withAccessorIndex index: Int, mode: GLTF.Mesh.Primitive.Mode) throws -> SCNGeometryElement {
-        if let cache = try sceneData.load(\.accessors, index: index) as? SCNGeometryElement { return cache }
+        if index < sceneData.accessors.count, let cache = sceneData.accessors[index] as? SCNGeometryElement {
+            return cache
+        }
         let gltfAccessor = try gltf.load(\.accessors, keyName: "accessors")[index]
         let geometryElement = try SCNGeometryElement(accessor: gltfAccessor, mode: mode, loader: self)
         sceneData.accessors[index] = geometryElement
@@ -105,7 +121,9 @@ open class VRMSceneLoader {
     }
 
     func inverseBindMatrix(withAccessorIndex index: Int) throws -> [InverseBindMatrix] {
-        if let cache = try sceneData.load(\.accessors, index: index) as? [InverseBindMatrix] { return cache }
+        if index < sceneData.accessors.count, let cache = sceneData.accessors[index] as? [InverseBindMatrix] {
+            return cache
+        }
         let gltfAccessor = try gltf.load(\.accessors, keyName: "accessors")[index]
         let ibm = try [InverseBindMatrix](accessor: gltfAccessor, loader: self)
         sceneData.accessors[index] = ibm
@@ -124,7 +142,9 @@ open class VRMSceneLoader {
 
     func bufferView(withBufferViewIndex index: Int) throws -> (bufferView: Data, stride: Int?) {
         let gltfBufferView = try gltf.load(\.bufferViews, keyName: "bufferViews")[index]
-        if let cache = try sceneData.load(\.bufferViews, index: index) { return (cache, gltfBufferView.byteStride) }
+        if index < sceneData.bufferViews.count, let cache = sceneData.bufferViews[index] {
+            return (cache, gltfBufferView.byteStride)
+        }
         let buffer = try self.buffer(withBufferIndex: gltfBufferView.buffer)
         let bufferView = buffer.subdata(in: gltfBufferView.byteOffset..<gltfBufferView.byteOffset + gltfBufferView.byteLength)
         sceneData.bufferViews[index] = bufferView
@@ -132,7 +152,9 @@ open class VRMSceneLoader {
     }
 
     private func buffer(withBufferIndex index: Int) throws -> Data {
-        if let cache = try sceneData.load(\.buffers, index: index) { return cache }
+        if index < sceneData.buffers.count, let cache = sceneData.buffers[index] {
+            return cache
+        }
         let gltfBuffer = try gltf.load(\.buffers, keyName: "buffers")[index]
         let buffer = try Data(buffer: gltfBuffer, relativeTo: rootDirectory, vrm: vrm)
         sceneData.buffers[index] = buffer
@@ -140,7 +162,9 @@ open class VRMSceneLoader {
     }
 
     func material(withMaterialIndex index: Int) throws -> SCNMaterial {
-        if let cache = try sceneData.load(\.materials, index: index) { return cache }
+        if index < sceneData.materials.count, let cache = sceneData.materials[index] {
+            return cache
+        }
         let gltfMaterial = try gltf.load(\.materials, keyName: "materials")[index]
         let material = try SCNMaterial(material: gltfMaterial, loader: self)
         sceneData.materials[index] = material
@@ -148,7 +172,9 @@ open class VRMSceneLoader {
     }
 
     func texture(withTextureIndex index: Int) throws -> SCNMaterialProperty {
-        if let cache = try sceneData.load(\.textures, index: index) { return cache }
+        if index < sceneData.textures.count, let cache = sceneData.textures[index] {
+            return cache
+        }
         let gltfTexture = try gltf.load(\.textures, keyName: "textures")[index]
         let texture = SCNMaterialProperty(contents: try image(withImageIndex: gltfTexture.source))
         if let sampler = gltfTexture.sampler {
@@ -161,10 +187,19 @@ open class VRMSceneLoader {
         return texture
     }
 
+    /// Loads an image with the given index from the VRM file
+    /// - Parameter index: The index of the image to load
+    /// - Returns: The loaded platform-specific image (UIImage on iOS, NSImage on macOS)
     func image(withImageIndex index: Int) throws -> PlatformImage {
-        if let cache = try sceneData.load(\.images, index: index) { return cache }
+        if index < sceneData.images.count, let cache = sceneData.images[index] {
+            return cache
+        }
         let gltfImage = try gltf.load(\.images, keyName: "images")[index]
-        let image = try PlatformImage(image: gltfImage, relativeTo: rootDirectory, loader: self)
+        #if canImport(UIKit)
+        let image = try UIImage(image: gltfImage, relativeTo: rootDirectory, loader: self)
+        #elseif canImport(AppKit)
+        let image = try NSImage(image: gltfImage, relativeTo: rootDirectory, loader: self)
+        #endif
         sceneData.images[index] = image
         return image
     }


### PR DESCRIPTION
# Pull Request: Add macOS Support for VRMKit

This pull request implements significant updates to the VRMKit project, adding full support for macOS platforms (macOS 12+) alongside existing support for iOS and watchOS. These changes enable the loading, rendering, and manipulation of VRM files using the same APIs that were previously available only on iOS.

## Changes Made

The following files and changes are included in this PR:

### Modified Files
- **`Example/Example.xcodeproj/project.pbxproj`**
  - Incremented `objectVersion` from 53 to 54.
  - Added `DEVELOPMENT_TEAM` identifier for code signing.

- **`Example/MacExample.xcodeproj/project.pbxproj`** (new)
  - Created project file for the macOS example application.

- **`Example/MacExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata`** (new)
  - Created workspace file for the macOS project.

- **`Example/MacExample/AppDelegate.swift`** (new)
  - Added the AppDelegate class to manage app lifecycle events.

- **`Example/MacExample/ContentView.swift`** (new)
  - Created the main content view with UI elements to control VRM model interactions.

- **Assets and Resources**: Created necessary asset folders and files such as `AccentColor`, `AppIcon`, and other UI resources.

- **`Example/MacExample/MacExample.intentfile`** (new)
  - Defined entitlements for macOS sandboxing.

- **`Example/MacExample/ViewModel.swift`** (new)
  - Implemented the view model to manage the state and actions of the UI.

- **`README.md`** and **`SETUP.md`** (new)
  - Updated documentation with details on usage and setup instructions for the macOS example.

- **`Package.swift`** 
  - Expanded platform support to include macOS 12.0+.

- **Source Files**: Various modifications in `Sources/VRMSceneKit` to accommodate platform-specific changes for macOS compatibility. This includes adding type aliases for `UIImage` and `NSImage`, updating methods to handle images and colors, and ensuring proper type handling across platforms.

## Why These Changes?
These changes aim to broaden the usability of VRMKit by providing native support for macOS applications. This allows developers to build rich, interactive experiences using VRM files on macOS, leveraging SwiftUI for modern UI development.

### Summary of Changes
- Added a complete macOS example project showcasing VRMKit functionality.
- Updated project configurations to include macOS support.
- Enhanced various source files to handle platform differences between iOS and macOS.
- Added comprehensive documentation to guide developers on how to use VRMKit for macOS applications.

## Closed Issues
- Resolves #52 - Introduction of macOS support in VRMKit.
- Resolves #53 - MacExample project demonstrating VRMKit usage on macOS.

This PR paves the way for further enhancements and contributions by integrating macOS support into the existing VRMKit framework. 

Thank you for considering this pull request!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded platform support to include macOS 12.0+, introducing a demo application that showcases interactive VRM model rendering with controls for facial expressions and rotations.
  - Improved cross-platform image and color handling for a more consistent visual experience on both iOS and macOS.

- **Documentation**
  - Added comprehensive setup guides and updated support documents to help users integrate and run the new macOS features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->